### PR TITLE
Keybase v6.4.0 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ flatpak-builder --user --install --force-clean builddir io.keybase.Keybase.yml
 ```
 
 Now you can run it like any other flatpak.
+
+## Updating
+
+This respository provides flatpak for a fixed version of keybase. See [here](https://github.com/RalfJung/io.keybase.Keybase/blob/master/io.keybase.Keybase.yml#L54) for current version.
+
+To update keybase flatpak you need up date this line (see comment for where to find latest release file name), and then rebuild and install with command above. This should preseve you settings & database.

--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ Now you can run it like any other flatpak.
 
 This respository provides flatpak for a fixed version of keybase. See [here](https://github.com/RalfJung/io.keybase.Keybase/blob/master/io.keybase.Keybase.yml#L54) for current version.
 
-To update keybase flatpak you need up date this line (see comment for where to find latest release file name), and then rebuild and install with command above. This should preseve you settings & database.
+To update keybase flatpak you need up date this line (see comment for where to find latest release file name), and then rebuild and install with the command above.
+ This should preserve your settings & database.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Now you can run it like any other flatpak.
 
 ## Updating
 
-This respository provides flatpak for a fixed version of keybase.
+This repository provides a flatpak for a fixed version of keybase.
 See [here](https://github.com/RalfJung/io.keybase.Keybase/blob/master/io.keybase.Keybase.yml#L54) for the current version.
 
-To update keybase flatpak you need up date this line (see comment for where to find latest release file name), and then rebuild and install with the command above.
- This should preserve your settings & database.
+To update the keybase version, you need up date this line (see comment for where to find latest release file name), and then rebuild and install with the command above.
+This should preserve your settings & database.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Now you can run it like any other flatpak.
 
 ## Updating
 
-This respository provides flatpak for a fixed version of keybase. See [here](https://github.com/RalfJung/io.keybase.Keybase/blob/master/io.keybase.Keybase.yml#L54) for current version.
+This respository provides flatpak for a fixed version of keybase.
+See [here](https://github.com/RalfJung/io.keybase.Keybase/blob/master/io.keybase.Keybase.yml#L54) for the current version.
 
 To update keybase flatpak you need up date this line (see comment for where to find latest release file name), and then rebuild and install with the command above.
  This should preserve your settings & database.

--- a/io.keybase.Keybase.yml
+++ b/io.keybase.Keybase.yml
@@ -51,7 +51,8 @@ modules:
       - type: file
         dest-filename: keybase.deb
         # Filename found in https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages.
-        url: https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_6.2.8-20240306193933.e38523abbe_amd64.deb
-        sha256: de8f24734e1294dcaf7f2644bdf93b0cb77d7a036ea4daac56cfac51018a08e9
+        url: https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_6.4.0-20240821175720.3212f60cc5_amd64.deb
+        sha256: 386b9c90c5170f37c720c8506a060964e6d5e16e8bb9fa9378888283e7393233
       - type: file
         path: keybase.sh
+        tag: '6.4.0'  # Note that this doesn't appear in flatpak app version feild...

--- a/io.keybase.Keybase.yml
+++ b/io.keybase.Keybase.yml
@@ -55,4 +55,3 @@ modules:
         sha256: 386b9c90c5170f37c720c8506a060964e6d5e16e8bb9fa9378888283e7393233
       - type: file
         path: keybase.sh
-        tag: '6.4.0'  # Note that this doesn't appear in flatpak app version feild...


### PR DESCRIPTION
This updates keybase to version 6.4.0 (which fixes #5). 
It also adds some notes on updates to README.md