### PR TITLE
Keybase v6.5.1 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ flatpak-builder --user --install --force-clean builddir io.keybase.Keybase.yml
 ```
 
 Now you can run it like any other flatpak.
+
+## Updating
+
+This respository provides flatpak for a fixed version of keybase. See [here](https://github.com/RalfJung/io.keybase.Keybase/blob/master/io.keybase.Keybase.yml#L54) for current version.
+
+To update keybase flatpak you need up date this line (see comment for where to find latest release file name), and then rebuild and install with command above. This should preseve you settings & database.

--- a/io.keybase.Keybase.yml
+++ b/io.keybase.Keybase.yml
@@ -51,7 +51,8 @@ modules:
       - type: file
         dest-filename: keybase.deb
         # Filename found in https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages.
-        url: https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_6.2.8-20240306193933.e38523abbe_amd64.deb
-        sha256: de8f24734e1294dcaf7f2644bdf93b0cb77d7a036ea4daac56cfac51018a08e9
+        url: https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_6.4.0-20240821175720.3212f60cc5_amd64.deb
+        sha256: 386b9c90c5170f37c720c8506a060964e6d5e16e8bb9fa9378888283e7393233
       - type: file
         path: keybase.sh
+        tag: '6.4.0'  # Note that this doesn't appear in flatpak app version feild...

--- a/io.keybase.Keybase.yml
+++ b/io.keybase.Keybase.yml
@@ -1,9 +1,9 @@
 app-id: io.keybase.Keybase
 
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '22.08'
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 
 command: keybase
@@ -51,8 +51,7 @@ modules:
       - type: file
         dest-filename: keybase.deb
         # Filename found in https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages.
-        url: https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_6.4.0-20240821175720.3212f60cc5_amd64.deb
-        sha256: 386b9c90c5170f37c720c8506a060964e6d5e16e8bb9fa9378888283e7393233
+        url: https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_6.5.1-20250428154451.19f9cfeddb_amd64.deb
+        sha256: 3c22a2d656af1b02db0a8313306e21e8f253233c1102ee78d9e62a0c32b35386
       - type: file
         path: keybase.sh
-        tag: '6.4.0'  # Note that this doesn't appear in flatpak app version feild...


### PR DESCRIPTION
keybase flatpak stopped working again. This is another fix that worked for me. I had to downgrade sdk to avoid runtime errors and blank screen.